### PR TITLE
Power saving mode for Ends

### DIFF
--- a/CC2530DB/GenericApp.ewp
+++ b/CC2530DB/GenericApp.ewp
@@ -1447,6 +1447,7 @@
                 <option>
                     <name>CCDefines</name>
                     <state>HAL_BOARD_TARGET</state>
+                    <state>POWER_SAVING</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>
@@ -3731,6 +3732,7 @@
                     <state>HAL_BOARD_TARGET</state>
                     <state>HAL_PA_LNA_CC2592</state>
                     <state>APP_TX_POWER=19</state>
+                    <state>POWER_SAVING</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>
@@ -6017,6 +6019,7 @@
                     <state>HAL_BOARD_TARGET</state>
                     <state>HAL_PA_LNA</state>
                     <state>APP_TX_POWER=19</state>
+                    <state>POWER_SAVING</state>
                 </option>
                 <option>
                     <name>CCPreprocFile</name>

--- a/Source/zcl_app.c
+++ b/Source/zcl_app.c
@@ -145,7 +145,7 @@ static void zclApp_InitCO2Uart(void) {
     halUARTConfig.callBackFunc = NULL;
     HalUARTInit();
     if (HalUARTOpen(CO2_UART_PORT, &halUARTConfig) == HAL_UART_SUCCESS) {
-        LREPMaster("Initialized sensair \r\n");
+        LREPMaster("Initialized CO2 UART \r\n");
     }
 }
 
@@ -228,7 +228,7 @@ static void zclApp_InitSensors(void) {
         LREPMaster("Sensor type UNKNOWN\r\n");
         break;
     }
-
+    osal_pwrmgr_task_state(zclApp_TaskID, PWRMGR_CONSERVE);
 }
 
 static void zclApp_StopSensorDetection(void) {
@@ -238,6 +238,7 @@ static void zclApp_StopSensorDetection(void) {
 static void zclApp_DetectSensorType(void) {
     static uint8 currentSensorsReadingPhase = 0;
     uint16 result = 0;
+    osal_pwrmgr_task_state(zclApp_TaskID, PWRMGR_HOLD);
     if (sensorType == UNKNOWN) {
         switch (currentSensorsReadingPhase++) {
         case 0:
@@ -288,6 +289,7 @@ static void zclApp_ReadSensors(void) {
     int16 temp;
     switch (currentSensorsReadingPhase++) {
     case 0:
+        osal_pwrmgr_task_state(zclApp_TaskID, PWRMGR_HOLD);
         switch (sensorType) {
         case SENSEAIR:
             SenseAir_RequestMeasure();
@@ -332,6 +334,7 @@ static void zclApp_ReadSensors(void) {
 
     case 4:
         zclApp_ReadBME280(&bme_dev);
+        osal_pwrmgr_task_state(zclApp_TaskID, PWRMGR_CONSERVE);
         break;
 
     default:


### PR DESCRIPTION
All End device configuration work in power save mode. 
This lowers the temperature of the 2530 chip so that the temperature sensors display more accurate data.